### PR TITLE
feat: Add tags to Units

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -601,6 +601,12 @@ for org in sample_orgs:
     for section in get_sections(sample_taxonomy_course):
         for subsection in get_subsections(section):
             for unit in get_units(subsection):
+                # Tag units
+                logger.info(f"Tagging {unit.location}")
+                tagify_object(
+                    unit.location,
+                    generated_taxonomies
+                )
                 for child in unit.get_children():
                     logger.info(f"Tagging {child.location}")
                     tagify_object(


### PR DESCRIPTION
### Description
Implements tagging Units in the sample courses. This should help with testing features/functionality related to tags on units.

### Related Tickets:
- https://github.com/openedx/modular-learning/issues/118

### Testing Instructions
Similar to what is mentioned in the README:
1. To begin, clone this repo inside a directory so it can be accessed from within the devstack (eg: `/edx/src/`)
1. Set the `TAXONOMY_SAMPLE_PATH` variable inside the `generate.py` file to point to the cloned repo inside your devstack/tutor environment, eg: `/edx/src/taxonomy-sample-data`
1. To run the script, enter the LMS shell (`make lms-shell`) and run the following command:
    ```sh
    python manage.py cms shell < /path/to/taxonomy-sample-data/generate.py
    ```

4. The script should run to completion, you'll notice it tagging the the units (vertical blocks) in the logs of the script

---
Private-ref: [FAL-3523](https://tasks.opencraft.com/browse/FAL-3523)