### PR TITLE
fix: tag_object expects a string object_id (not an OpaqueKey)

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -427,7 +427,7 @@ def tagify_object(object_id, taxonomies):
                 tag_values.append(second_tag["value"])
         try:
             tag_object(
-                object_id=object_id,
+                object_id=str(object_id),
                 taxonomy=taxonomy,
                 tags=tag_values
             )


### PR DESCRIPTION
### Description

Fixes bug with this repo revealed by recent changes to the content_tagging API.

Previously, the content_tagging api simply forwarded `tag_object` requests to the [tagging API's `tag_object` method](https://github.com/openedx/openedx-learning/blob/ebd23b00c0bafcd5422d711728fec9c332142e72/openedx_tagging/core/tagging/api.py#L322), which expects an `object_id: str`, but was working even when `object_id: UsageKey`. However, after [this change](https://github.com/openedx/edx-platform/pull/34386/files#diff-622b94f51cb73a9282ceead7fad64cc289a4e2ec47bebb450ad575b96d2971d7R238), the content_tagging API now does not work unless `object_id: str`.

### Testing instructions

1. Ensure you're running latest edx-platform:master
2. Update and run generate.py according to README instructions.
3. Ensure it completes without error.

Private-ref: [FAL-3692](https://tasks.opencraft.com/browse/FAL-3692)